### PR TITLE
[Docs][Bot] Update README and fix watch conversation UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,67 @@
 # Bus Watcher Bot
 
-Телеграм-бот для мониторинга свободных мест по маршрутам.
+A Telegram bot that monitors SmileBus ticket availability and sends a notification the moment seats become available on a selected route.
 
-## Команды
+## Features
 
-- `/watch <city_from_id> <city_to_id> <дата> <начало_время> <конец_время>`
-  Пример: `/watch 1 58 05.12.2025 18:00 21:10`
-- `/list` — список ваших задач
-- `/stop <watch_id>` — остановить задачу
+- **Step-by-step booking flow** — city, date, and time range selection via inline keyboards; all 33 SmileBus cities supported with route-aware destination filtering
+- **Flexible time input** — choose a preset range (morning / afternoon / evening) or enter a custom start/end time manually
+- **Live task list** — `/list` displays all watches in a single message with an inline stop button per active task
+- **Auto-recovery** — active watches are restored automatically on bot restart
+- **Stale task cleanup** — watches past their travel date are deactivated on startup
+- **Resilient polling** — API errors trigger a 30-second retry instead of crashing the watch task
 
-### Создайте .env с переменными:
+## Project Structure
 
-- `BOT_TOKEN=<токен_бота>`
-- `DATABASE_PATH=watcher.db`
+```
+main.py               — entry point; builds Application with post_init hook
+config.py             — environment config (BOT_TOKEN, DB_PATH, TIME_RANGES)
+db.py                 — async SQLite wrapper (aiosqlite)
+handlers/
+  commands.py         — /start (reply keyboard), /help, unknown message fallback
+  watch.py            — ConversationHandler for /watch (FROM_CITY → TO_CITY → DATE → TIME → CONFIRM)
+  list_handler.py     — /list, /stop, inline stop callback
+services/
+  smilebus.py         — SmileBusAPI: city cache, route graph, schedule fetch
+  watcher.py          — background polling loop with retry logic
+```
+
+## Getting Started
+
+### 1. Install dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+### 2. Configure environment
+
+Copy `.env.example` to `.env` and fill in your values:
+
+```
+BOT_TOKEN=your_telegram_bot_token
+DATABASE_PATH=watcher.db
+```
+
+### 3. Run
+
+```bash
+python main.py
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/start` | Show welcome message and main menu |
+| `/watch` | Start a new ticket watch (guided dialog) |
+| `/list` | View all watches with inline stop controls |
+| `/stop <id>` | Stop a watch by ID |
+| `/help` | Show usage instructions |
+
+## Tech Stack
+
+- [python-telegram-bot](https://github.com/python-telegram-bot/python-telegram-bot) 22.7
+- [aiohttp](https://docs.aiohttp.org/)
+- [aiosqlite](https://aiosqlite.omnilib.dev/)
+- [python-dotenv](https://github.com/theskumar/python-dotenv)

--- a/handlers/watch.py
+++ b/handlers/watch.py
@@ -50,7 +50,7 @@ def _date_keyboard() -> InlineKeyboardMarkup:
 
 def _time_keyboard() -> InlineKeyboardMarkup:
     rows = [
-        [InlineKeyboardButton(label, callback_data=f"time:{start}:{end}")]
+        [InlineKeyboardButton(label, callback_data=f"time:{start}|{end}")]
         for start, end, label in TIME_RANGES
     ]
     rows.append([InlineKeyboardButton("✏️ Ввести вручную", callback_data="time:manual")])
@@ -118,7 +118,7 @@ async def select_date(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
     value = query.data.split(":", 1)[1]
 
     if value == "manual":
-        await query.edit_message_text("Введи дату в формате ДД.ММ.ГГГГ:")
+        await query.edit_message_text("Введи дату (ДД.ММ.ГГГГ):")
         context.user_data["awaiting"] = "date"
         return DATE
 
@@ -135,7 +135,7 @@ async def manual_date_input(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     try:
         datetime.strptime(text, "%d.%m.%Y")
     except ValueError:
-        await update.message.reply_text("Неверный формат. Введи дату как ДД.ММ.ГГГГ:")
+        await update.message.reply_text("Неверный формат. Введи дату (ДД.ММ.ГГГГ):")
         return DATE
 
     context.user_data["date"] = text
@@ -152,10 +152,10 @@ async def select_time(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
     value = query.data.split(":", 1)[1]
 
     if value == "manual":
-        await query.edit_message_text("Введи время начала в формате ЧЧ:ММ:")
+        await query.edit_message_text("Введи время начала (ЧЧ:ММ):")
         return TIME_MANUAL_START
 
-    start, end = value.split(":")
+    start, end = value.split("|")
     context.user_data["start_time"] = start
     context.user_data["end_time"] = end
     return await _show_confirm(update, context)
@@ -166,11 +166,11 @@ async def manual_time_start(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     try:
         datetime.strptime(text, "%H:%M")
     except ValueError:
-        await update.message.reply_text("Неверный формат. Введи время начала как ЧЧ:ММ:")
+        await update.message.reply_text("Неверный формат. Введи время начала (ЧЧ:ММ):")
         return TIME_MANUAL_START
 
     context.user_data["start_time"] = text
-    await update.message.reply_text("Введи время окончания в формате ЧЧ:ММ:")
+    await update.message.reply_text("Введи время окончания (ЧЧ:ММ):")
     return TIME_MANUAL_END
 
 
@@ -179,7 +179,7 @@ async def manual_time_end(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     try:
         datetime.strptime(text, "%H:%M")
     except ValueError:
-        await update.message.reply_text("Неверный формат. Введи время окончания как ЧЧ:ММ:")
+        await update.message.reply_text("Неверный формат. Введи время окончания (ЧЧ:ММ):")
         return TIME_MANUAL_END
 
     context.user_data["end_time"] = text


### PR DESCRIPTION
Description
Rewrites the README in professional English to reflect the current project structure, and fixes two issues in the watch conversation flow: a callback data parsing bug and awkward format hint copy.

Key changes
- `README.md` — full rewrite in English: features overview, project structure, getting started guide, commands table, tech stack
- `handlers/watch.py` — fix `ValueError: too many values to unpack` in `select_time`: change callback data separator from `:` to `|` so `06:00|10:00` unpacks correctly
- `handlers/watch.py` — replace `"ЧЧ:ММ:"` / `"ДД.ММ.ГГГГ:"` suffix style with parenthetical format `"(ЧЧ:ММ):"` / `"(ДД.ММ.ГГГГ):"` to avoid double-colon visual artefact

Note: all three items from the Issue #3 scope (structured logging, /help command, API retry logic) were already shipped as part of PR #5. This PR closes the issue.

Closes #3