### PR TITLE
[Fix] Untranslated /stop usage message + README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A Telegram bot that monitors SmileBus ticket availability and sends a notificati
 
 - **Step-by-step booking flow** — city, date, and time range selection via inline keyboards; all 33 SmileBus cities supported with route-aware destination filtering
 - **Flexible time input** — choose a preset range (morning / afternoon / evening) or enter a custom start/end time manually
+- **EN/RU interface** — switch language at any time with `/language`; all bot messages are fully translated
 - **Live task list** — `/list` displays all watches in a single message with an inline stop button per active task
 - **Auto-recovery** — active watches are restored automatically on bot restart
 - **Stale task cleanup** — watches past their travel date are deactivated on startup
@@ -17,10 +18,12 @@ A Telegram bot that monitors SmileBus ticket availability and sends a notificati
 main.py               — entry point; builds Application with post_init hook
 config.py             — environment config (BOT_TOKEN, DB_PATH, TIME_RANGES)
 db.py                 — async SQLite wrapper (aiosqlite)
+locales.py            — EN/RU string table and t() helper
 handlers/
   commands.py         — /start (reply keyboard), /help, unknown message fallback
   watch.py            — ConversationHandler for /watch (FROM_CITY → TO_CITY → DATE → TIME → CONFIRM)
   list_handler.py     — /list, /stop, inline stop callback
+  language.py         — /language command and language-switch callback
 services/
   smilebus.py         — SmileBusAPI: city cache, route graph, schedule fetch
   watcher.py          — background polling loop with retry logic
@@ -57,6 +60,7 @@ python main.py
 | `/watch` | Start a new ticket watch (guided dialog) |
 | `/list` | View all watches with inline stop controls |
 | `/stop <id>` | Stop a watch by ID |
+| `/language` | Switch interface language (EN / RU) |
 | `/help` | Show usage instructions |
 
 ## Tech Stack

--- a/handlers/list_handler.py
+++ b/handlers/list_handler.py
@@ -126,7 +126,7 @@ async def cmd_stop(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     user_id = update.effective_user.id
     lang = await get_lang(user_id, context, db)
     if not context.args:
-        await update.message.reply_text("Usage: /stop <watch_id>")
+        await update.message.reply_text(t(lang, "stop_usage"))
         return
     watch_id = int(context.args[0])
     await _stop_watch(watch_id, context)

--- a/locales.py
+++ b/locales.py
@@ -60,6 +60,7 @@ STRINGS: dict[str, dict] = {
         "tickets_found": "🎉 Билеты найдены!\nДата: {date}\nВремя: {time}\nМест: {count}\nМаршрут: {route}",
         "lang_prompt": "Текущий язык: 🇷🇺 Русский\nВыбери язык:",
         "lang_set": "🇷🇺 Язык изменён на русский.",
+        "stop_usage": "Использование: /stop <id_задачи>",
     },
     "en": {
         "keyboard_watch": "🔍 Watch tickets",
@@ -118,6 +119,7 @@ STRINGS: dict[str, dict] = {
         "tickets_found": "🎉 Tickets found!\nDate: {date}\nTime: {time}\nSeats: {count}\nRoute: {route}",
         "lang_prompt": "Current language: 🇬🇧 English\nChoose language:",
         "lang_set": "🇬🇧 Language changed to English.",
+        "stop_usage": "Usage: /stop <watch_id>",
     },
 }
 


### PR DESCRIPTION
## Description

Two small issues found after the i18n PR was merged.

## Key changes

- `locales.py` — added `stop_usage` key to both `ru` and `en` string tables
- `handlers/list_handler.py` — replaced hardcoded `"Usage: /stop <watch_id>"` with `t(lang, "stop_usage")`
- `README.md` — added `/language` to Commands table and Features; added `locales.py` and `language.py` to Project Structure

Closes #11