### PR TITLE
[Feature] Min seats filter in /watch flow

### DIFF
--- a/db.py
+++ b/db.py
@@ -36,6 +36,13 @@ class Database:
                     lang TEXT NOT NULL DEFAULT 'ru'
                 )
             """)
+            try:
+                await db.execute(
+                    "ALTER TABLE watches ADD COLUMN min_seats INTEGER NOT NULL DEFAULT 1"
+                )
+                await db.commit()
+            except Exception:
+                pass  # column already exists
             await db.commit()
 
     async def add_history(self, msg: str):
@@ -46,11 +53,11 @@ class Database:
             )
             await db.commit()
 
-    async def add_watch(self, user_id, date, start_time, end_time, city_from_id, city_to_id) -> int:
+    async def add_watch(self, user_id, date, start_time, end_time, city_from_id, city_to_id, min_seats: int = 1) -> int:
         async with aiosqlite.connect(self.path) as db:
             cursor = await db.execute(
-                "INSERT INTO watches (user_id, date, start_time, end_time, city_from_id, city_to_id, active) VALUES (?, ?, ?, ?, ?, ?, 1)",
-                (user_id, date, start_time, end_time, city_from_id, city_to_id)
+                "INSERT INTO watches (user_id, date, start_time, end_time, city_from_id, city_to_id, active, min_seats) VALUES (?, ?, ?, ?, ?, ?, 1, ?)",
+                (user_id, date, start_time, end_time, city_from_id, city_to_id, min_seats)
             )
             await db.commit()
             return cursor.lastrowid
@@ -62,13 +69,13 @@ class Database:
 
     async def get_active_watches(self):
         async with aiosqlite.connect(self.path) as db:
-            cursor = await db.execute("SELECT id, user_id, date, start_time, end_time, city_from_id, city_to_id FROM watches WHERE active = 1")
+            cursor = await db.execute("SELECT id, user_id, date, start_time, end_time, city_from_id, city_to_id, min_seats FROM watches WHERE active = 1")
             return await cursor.fetchall()
 
     async def list_watches(self, user_id):
         async with aiosqlite.connect(self.path) as db:
             cursor = await db.execute(
-                "SELECT id, date, start_time, end_time, city_from_id, city_to_id, active FROM watches WHERE user_id = ?",
+                "SELECT id, date, start_time, end_time, city_from_id, city_to_id, active, min_seats FROM watches WHERE user_id = ?",
                 (user_id,)
             )
             return await cursor.fetchall()

--- a/handlers/list_handler.py
+++ b/handlers/list_handler.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 def _sort_key(row):
     """Active first, then by travel date descending."""
-    w_id, date, start, end, from_id, to_id, active = row
+    w_id, date, start, end, from_id, to_id, active, *_ = row
     try:
         parsed = datetime.strptime(date, "%d.%m.%Y")
     except ValueError:
@@ -34,7 +34,7 @@ def _build_list_message(rows: list, page: int, api, lang: str) -> tuple[str, Inl
     lines = []
     last_group = None
     for row in page_rows:
-        w_id, date, start, end, from_id, to_id, active = row
+        w_id, date, start, end, from_id, to_id, active, *_ = row
         group = "active" if active else "done"
         if group != last_group:
             lines.append(t(lang, "section_active") if active else t(lang, "section_completed"))
@@ -49,7 +49,7 @@ def _build_list_message(rows: list, page: int, api, lang: str) -> tuple[str, Inl
     buttons = []
 
     for row in page_rows:
-        w_id, date, start, end, from_id, to_id, active = row
+        w_id, date, start, end, from_id, to_id, active, *_ = row
         if active:
             buttons.append([InlineKeyboardButton(
                 t(lang, "btn_stop", watch_id=w_id), callback_data=f"stop:{w_id}"

--- a/handlers/watch.py
+++ b/handlers/watch.py
@@ -21,7 +21,7 @@ from services.watcher import run_watch
 logger = logging.getLogger(__name__)
 
 # Conversation states
-FROM_CITY, TO_CITY, DATE, TIME_MANUAL_START, TIME_MANUAL_END, CONFIRM = range(6)
+FROM_CITY, TO_CITY, DATE, TIME_MANUAL_START, TIME_MANUAL_END, SEATS, CONFIRM = range(7)
 
 _CHUNK = 3  # buttons per row
 
@@ -67,6 +67,18 @@ def _time_keyboard(lang: str) -> InlineKeyboardMarkup:
     rows.append([InlineKeyboardButton(t(lang, "btn_enter_manual"), callback_data="time:manual")])
     rows.append([InlineKeyboardButton(t(lang, "btn_cancel"), callback_data="watch_cancel")])
     return InlineKeyboardMarkup(rows)
+
+
+def _seats_keyboard(lang: str) -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup([
+        [
+            InlineKeyboardButton("1", callback_data="seats:1"),
+            InlineKeyboardButton("2", callback_data="seats:2"),
+            InlineKeyboardButton("3", callback_data="seats:3"),
+        ],
+        [InlineKeyboardButton(t(lang, "btn_enter_manual"), callback_data="seats:manual")],
+        [InlineKeyboardButton(t(lang, "btn_cancel"), callback_data="watch_cancel")],
+    ])
 
 
 def _confirm_keyboard(lang: str) -> InlineKeyboardMarkup:
@@ -184,7 +196,7 @@ async def select_time(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
     start, end = value.split("|")
     context.user_data["start_time"] = start
     context.user_data["end_time"] = end
-    return await _show_confirm(update, context, lang)
+    return await _show_seats(update, context, lang)
 
 
 async def manual_time_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
@@ -213,6 +225,43 @@ async def manual_time_end(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         return TIME_MANUAL_END
 
     context.user_data["end_time"] = text
+    return await _show_seats(update, context, lang)
+
+
+async def _show_seats(update: Update, context: ContextTypes.DEFAULT_TYPE, lang: str) -> int:
+    text = t(lang, "select_seats")
+    if update.callback_query:
+        await update.callback_query.edit_message_text(text, reply_markup=_seats_keyboard(lang))
+    else:
+        await update.message.reply_text(text, reply_markup=_seats_keyboard(lang))
+    return SEATS
+
+
+async def select_seats(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    query = update.callback_query
+    await query.answer()
+    value = query.data.split(":")[1]
+    db = context.bot_data["db"]
+    lang = await get_lang(update.effective_user.id, context, db)
+
+    if value == "manual":
+        await query.edit_message_text(t(lang, "enter_seats_manual"))
+        return SEATS
+
+    context.user_data["min_seats"] = int(value)
+    return await _show_confirm(update, context, lang)
+
+
+async def manual_seats_input(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    text = update.message.text.strip()
+    db = context.bot_data["db"]
+    lang = await get_lang(update.effective_user.id, context, db)
+
+    if not text.isdigit() or int(text) < 1:
+        await update.message.reply_text(t(lang, "seats_invalid"))
+        return SEATS
+
+    context.user_data["min_seats"] = int(text)
     return await _show_confirm(update, context, lang)
 
 
@@ -223,7 +272,8 @@ async def _show_confirm(update: Update, context: ContextTypes.DEFAULT_TYPE, lang
     to_name = api.city_name(ud["to_id"])
 
     text = t(lang, "confirm_text", from_name=from_name, to_name=to_name,
-             date=ud["date"], start=ud["start_time"], end=ud["end_time"])
+             date=ud["date"], start=ud["start_time"], end=ud["end_time"],
+             min_seats=ud["min_seats"])
 
     if update.callback_query:
         await update.callback_query.edit_message_text(text, reply_markup=_confirm_keyboard(lang))
@@ -245,13 +295,13 @@ async def confirm_watch(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
 
     watch_id = await db.add_watch(
         user_id, ud["date"], ud["start_time"], ud["end_time"],
-        ud["from_id"], ud["to_id"],
+        ud["from_id"], ud["to_id"], ud["min_seats"],
     )
 
     task = asyncio.create_task(
         run_watch(
             watch_id, user_id, ud["date"], ud["start_time"], ud["end_time"],
-            ud["from_id"], ud["to_id"], context.bot, db, api,
+            ud["from_id"], ud["to_id"], context.bot, db, api, ud["min_seats"],
         )
     )
     active_tasks[watch_id] = task
@@ -261,7 +311,8 @@ async def confirm_watch(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
 
     await query.edit_message_text(
         t(lang, "watch_started_msg", from_name=from_name, to_name=to_name,
-          date=ud["date"], start=ud["start_time"], end=ud["end_time"])
+          date=ud["date"], start=ud["start_time"], end=ud["end_time"],
+          min_seats=ud["min_seats"])
     )
     return ConversationHandler.END
 
@@ -301,6 +352,10 @@ def build_watch_handler() -> ConversationHandler:
             ],
             TIME_MANUAL_END: [
                 MessageHandler(filters.TEXT & ~filters.COMMAND, manual_time_end),
+            ],
+            SEATS: [
+                CallbackQueryHandler(select_seats, pattern=r"^seats:"),
+                MessageHandler(filters.TEXT & ~filters.COMMAND, manual_seats_input),
             ],
             CONFIRM: [CallbackQueryHandler(confirm_watch, pattern=r"^confirm:")],
         },

--- a/locales.py
+++ b/locales.py
@@ -16,7 +16,8 @@ STRINGS: dict[str, dict] = {
             "  2. Выбери город назначения\n"
             "  3. Выбери дату\n"
             "  4. Выбери диапазон времени (или введи вручную)\n"
-            "  5. Подтверди — бот будет проверять каждые 10 сек\n\n"
+            "  5. Выбери минимальное кол-во мест\n"
+            "  6. Подтверди — бот будет проверять каждые 10 сек\n\n"
             "/list — список твоих задач с кнопкой остановки\n"
             "/stop <id> — остановить мониторинг по ID\n"
             "/language — сменить язык\n"
@@ -34,8 +35,11 @@ STRINGS: dict[str, dict] = {
         "time_start_invalid": "Неверный формат. Введи время начала (ЧЧ:ММ):",
         "enter_time_end": "Введи время окончания (ЧЧ:ММ):",
         "time_end_invalid": "Неверный формат. Введи время окончания (ЧЧ:ММ):",
-        "confirm_text": "Подтверди запуск мониторинга:\n\nМаршрут: {from_name} → {to_name}\nДата: {date}\nВремя: {start} — {end}",
-        "watch_started_msg": "🔍 Мониторинг запущен!\n\nМаршрут: {from_name} → {to_name}\nДата: {date}\nВремя: {start} — {end}",
+        "select_seats": "Выбери минимальное кол-во мест:",
+        "enter_seats_manual": "Введи кол-во мест (число ≥ 1):",
+        "seats_invalid": "Неверный ввод. Введи целое число ≥ 1:",
+        "confirm_text": "Подтверди запуск мониторинга:\n\nМаршрут: {from_name} → {to_name}\nДата: {date}\nВремя: {start} — {end}\nМест: ≥{min_seats}",
+        "watch_started_msg": "🔍 Мониторинг запущен!\n\nМаршрут: {from_name} → {to_name}\nДата: {date}\nВремя: {start} — {end}\nМест: ≥{min_seats}",
         "watch_cancelled": "❌ Отменено.",
         "btn_today": "Сегодня",
         "btn_tomorrow": "Завтра",
@@ -75,7 +79,8 @@ STRINGS: dict[str, dict] = {
             "  2. Choose destination city\n"
             "  3. Choose date\n"
             "  4. Choose time range (or enter manually)\n"
-            "  5. Confirm — bot checks every 10 sec\n\n"
+            "  5. Choose minimum number of seats\n"
+            "  6. Confirm — bot checks every 10 sec\n\n"
             "/list — your watches with stop button\n"
             "/stop <id> — stop watch by ID\n"
             "/language — change language\n"
@@ -93,8 +98,11 @@ STRINGS: dict[str, dict] = {
         "time_start_invalid": "Wrong format. Enter start time (HH:MM):",
         "enter_time_end": "Enter end time (HH:MM):",
         "time_end_invalid": "Wrong format. Enter end time (HH:MM):",
-        "confirm_text": "Confirm monitoring:\n\nRoute: {from_name} → {to_name}\nDate: {date}\nTime: {start} — {end}",
-        "watch_started_msg": "🔍 Monitoring started!\n\nRoute: {from_name} → {to_name}\nDate: {date}\nTime: {start} — {end}",
+        "select_seats": "Choose minimum number of seats:",
+        "enter_seats_manual": "Enter number of seats (≥ 1):",
+        "seats_invalid": "Invalid input. Enter a whole number ≥ 1:",
+        "confirm_text": "Confirm monitoring:\n\nRoute: {from_name} → {to_name}\nDate: {date}\nTime: {start} — {end}\nSeats: ≥{min_seats}",
+        "watch_started_msg": "🔍 Monitoring started!\n\nRoute: {from_name} → {to_name}\nDate: {date}\nTime: {start} — {end}\nSeats: ≥{min_seats}",
         "watch_cancelled": "❌ Cancelled.",
         "btn_today": "Today",
         "btn_tomorrow": "Tomorrow",

--- a/main.py
+++ b/main.py
@@ -42,10 +42,10 @@ async def post_init(application) -> None:
     ])
 
     watches = await db.get_active_watches()
-    for w_id, user_id, date, start_time, end_time, city_from_id, city_to_id in watches:
+    for w_id, user_id, date, start_time, end_time, city_from_id, city_to_id, min_seats in watches:
         task = asyncio.create_task(
             run_watch(w_id, user_id, date, start_time, end_time,
-                      city_from_id, city_to_id, application.bot, db, api)
+                      city_from_id, city_to_id, application.bot, db, api, min_seats)
         )
         active_tasks[w_id] = task
         logger.info("Restored watch #%d", w_id)

--- a/services/watcher.py
+++ b/services/watcher.py
@@ -10,12 +10,12 @@ from services.smilebus import SmileBusAPI
 logger = logging.getLogger(__name__)
 
 
-def _find_in_range(schedule: list, start_time_str: str, end_time_str: str) -> dict | None:
+def _find_in_range(schedule: list, start_time_str: str, end_time_str: str, min_seats: int = 1) -> dict | None:
     start = datetime.strptime(start_time_str, "%H:%M").time()
     end = datetime.strptime(end_time_str, "%H:%M").time()
     for item in schedule:
         t_val = datetime.strptime(item["time"], "%H:%M").time()
-        if start <= t_val <= end and item["count"] > 0:
+        if start <= t_val <= end and item["count"] >= min_seats:
             return item
     return None
 
@@ -31,6 +31,7 @@ async def run_watch(
     bot,
     db,
     api: SmileBusAPI,
+    min_seats: int = 1,
 ) -> None:
     lang = await db.get_user_lang(user_id)
     tz = pytz.timezone("Europe/Minsk")
@@ -49,7 +50,7 @@ async def run_watch(
 
         try:
             schedule = await api.fetch_schedule(date, city_from_id, city_to_id)
-            found = _find_in_range(schedule, start_time, end_time)
+            found = _find_in_range(schedule, start_time, end_time, min_seats)
             if found:
                 await bot.send_message(
                     chat_id=user_id,


### PR DESCRIPTION
Closes #13

## Scope
- `handlers/watch.py` — new `SEATS` state after time selection; keyboard with buttons 1/2/3 + manual input; validation for manual entry
- `locales.py` — 3 new keys, update `confirm_text`, `watch_started_msg`, `help_text` (RU + EN)
- `db.py` — `min_seats` column via `ALTER TABLE ... DEFAULT 1`, update add/get queries
- `services/watcher.py` — `_find_in_range` checks `count >= min_seats` instead of `count > 0`
- `main.py` — unpack `min_seats` when restoring active watches on startup